### PR TITLE
Use Twemoji to render emojis in puzzle scores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react-icons": "^3.9.0",
         "react-share": "^4.1.0",
         "react-transition-group": "^4.3.0",
+        "react-twemoji": "^0.5.0",
         "yaml-loader": "^0.6.0"
       },
       "devDependencies": {
@@ -13759,6 +13760,11 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
     "node_modules/lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
@@ -17364,6 +17370,22 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-twemoji": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/react-twemoji/-/react-twemoji-0.5.0.tgz",
+      "integrity": "sha512-xz3NLWTFCfWOmPd559jcFX4f976ORIPpL9SwdBQO5BZwIYD1U1vpbY2E6k2vwPCVH78s2m1GbG5jpHKGUPZ+gw==",
+      "dependencies": {
+        "lodash.isequal": "^4.5.0",
+        "prop-types": "^15.7.2",
+        "twemoji": "14.0.1"
+      },
+      "engines": {
+        "node": ">=5.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.2"
+      }
+    },
     "node_modules/read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -19762,6 +19784,62 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/twemoji": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-14.0.1.tgz",
+      "integrity": "sha512-eoqhea0sUhmC10iTacksyp1v9O4BP1jKmVqtK+Nztw40/dzawSHkXL3/xCpyh+mukmEvJ0Gw9VLvwZfQ9HKXDw==",
+      "dependencies": {
+        "fs-extra": "^8.0.1",
+        "jsonfile": "^5.0.0",
+        "twemoji-parser": "14.0.0",
+        "universalify": "^0.1.2"
+      }
+    },
+    "node_modules/twemoji-parser": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-14.0.0.tgz",
+      "integrity": "sha512-9DUOTGLOWs0pFWnh1p6NF+C3CkQ96PWmEFwhOVmT3WbecRC+68AIqpsnJXygfkFcp4aXbOp8Dwbhh/HQgvoRxA=="
+    },
+    "node_modules/twemoji/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/twemoji/node_modules/fs-extra/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/twemoji/node_modules/jsonfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+      "integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
+      "dependencies": {
+        "universalify": "^0.1.2"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/twemoji/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/type": {
@@ -31227,6 +31305,11 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
@@ -33821,6 +33904,16 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-twemoji": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/react-twemoji/-/react-twemoji-0.5.0.tgz",
+      "integrity": "sha512-xz3NLWTFCfWOmPd559jcFX4f976ORIPpL9SwdBQO5BZwIYD1U1vpbY2E6k2vwPCVH78s2m1GbG5jpHKGUPZ+gw==",
+      "requires": {
+        "lodash.isequal": "^4.5.0",
+        "prop-types": "^15.7.2",
+        "twemoji": "14.0.1"
+      }
+    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -35627,6 +35720,58 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "twemoji": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-14.0.1.tgz",
+      "integrity": "sha512-eoqhea0sUhmC10iTacksyp1v9O4BP1jKmVqtK+Nztw40/dzawSHkXL3/xCpyh+mukmEvJ0Gw9VLvwZfQ9HKXDw==",
+      "requires": {
+        "fs-extra": "^8.0.1",
+        "jsonfile": "^5.0.0",
+        "twemoji-parser": "14.0.0",
+        "universalify": "^0.1.2"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          },
+          "dependencies": {
+            "jsonfile": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+              "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+              "requires": {
+                "graceful-fs": "^4.1.6"
+              }
+            }
+          }
+        },
+        "jsonfile": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+          "integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^0.1.2"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        }
+      }
+    },
+    "twemoji-parser": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-14.0.0.tgz",
+      "integrity": "sha512-9DUOTGLOWs0pFWnh1p6NF+C3CkQ96PWmEFwhOVmT3WbecRC+68AIqpsnJXygfkFcp4aXbOp8Dwbhh/HQgvoRxA=="
     },
     "type": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-icons": "^3.9.0",
     "react-share": "^4.1.0",
     "react-transition-group": "^4.3.0",
+    "react-twemoji": "^0.5.0",
     "yaml-loader": "^0.6.0"
   },
   "devDependencies": {

--- a/src/styles/DailyPuzzleStyles.js
+++ b/src/styles/DailyPuzzleStyles.js
@@ -5,22 +5,22 @@ import { Global, css } from "@emotion/react"
 const DailyPuzzleStyles = () => (
   <Global
     styles={css`
-        .puzzle-score {
-            line-height: 1.2em;
-        }
+      .puzzle-score {
+        line-height: 1.2em;
+      }
 
-        .puzzle-score > div {
-            min-height: 1.2em;
-        }
+      .puzzle-score > div {
+        min-height: 1.2em;
+      }
 
-        .twemoji-puzzle {
-            width: 1.2em;
-            height: 1.2em;
-            line-height: 1.2em;
-            margin-right: 0.075em;
-            margin-left: 0.075em;
-            vertical-align: -30%;
-        }
+      .twemoji-puzzle {
+        width: 1.2em;
+        height: 1.2em;
+        line-height: 1.2em;
+        margin-right: 0.075em;
+        margin-left: 0.075em;
+        vertical-align: -30%;
+      }
     `}
   />
 )

--- a/src/styles/DailyPuzzleStyles.js
+++ b/src/styles/DailyPuzzleStyles.js
@@ -1,0 +1,28 @@
+import React from "react"
+import { Global, css } from "@emotion/react"
+
+/* Overrides GlobalStyles for daily puzzles-specific styling */
+const DailyPuzzleStyles = () => (
+  <Global
+    styles={css`
+        .puzzle-score {
+            line-height: 1.2em;
+        }
+
+        .puzzle-score > div {
+            min-height: 1.2em;
+        }
+
+        .twemoji-puzzle {
+            width: 1.2em;
+            height: 1.2em;
+            line-height: 1.2em;
+            margin-right: 0.075em;
+            margin-left: 0.075em;
+            vertical-align: -30%;
+        }
+    `}
+  />
+)
+
+export default DailyPuzzleStyles

--- a/src/templates/daily-puzzle.js
+++ b/src/templates/daily-puzzle.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { graphql } from "gatsby"
 import { css } from "@emotion/react"
-// import { Twemoji } from 'react-emoji-render'
+import Twemoji from 'react-twemoji'
 
 import Helmet from "../components/helmet"
 import Header from "../components/header"
@@ -9,6 +9,7 @@ import Footer from "../components/footer"
 // import Engage from "../components/engage"
 import { Main, AutoFitGrid } from "../styles/Containers"
 import GlobalStyles from "../styles/GlobalStyles"
+import DailyPuzzleStyles from "../styles/DailyPuzzleStyles"
 import { SectionHeading } from "../styles/Headings"
 import { colors, breakpoint } from "../styles/theme"
 import siteData from "../config/site-data.yml"
@@ -33,6 +34,7 @@ const DailyPuzzle = ({ data, pageContext }) => {
         // sharingAltText={`${profile.greeting} ${profile.name}. ${profile.tagline}`}
       />
       <GlobalStyles />
+      <DailyPuzzleStyles />
       <Header height={HEADER_HEIGHT} navBackground={colors.lighterBg} />
       <Main marginTop={`${HEADER_HEIGHT}px`}>
         <div
@@ -56,11 +58,9 @@ const DailyPuzzle = ({ data, pageContext }) => {
                 <h3>
                   {node.puzzle} {node.dayNumber}
                 </h3>
-                <div
-                  dangerouslySetInnerHTML={{
-                    __html: newlineToBr(node.resultText),
-                  }}
-                />
+                <div class='puzzle-score'>
+                  {renderPuzzleResult(node.resultText)}
+                </div>
               </div>
             ))}
         </AutoFitGrid>
@@ -68,6 +68,12 @@ const DailyPuzzle = ({ data, pageContext }) => {
       <Footer />
     </div>
   )
+}
+
+const renderPuzzleResult = (text) => {
+  const lines = text.split('\n')
+  const result = lines.map((line) => <Twemoji options={{ className: 'twemoji-puzzle', folder: 'svg', ext: '.svg' }}>{line}</Twemoji>)
+  return result;
 }
 
 export default DailyPuzzle

--- a/src/templates/daily-puzzle.js
+++ b/src/templates/daily-puzzle.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { graphql } from "gatsby"
 import { css } from "@emotion/react"
-import Twemoji from 'react-twemoji'
+import Twemoji from "react-twemoji"
 
 import Helmet from "../components/helmet"
 import Header from "../components/header"
@@ -58,7 +58,7 @@ const DailyPuzzle = ({ data, pageContext }) => {
                 <h3>
                   {node.puzzle} {node.dayNumber}
                 </h3>
-                <div class='puzzle-score'>
+                <div class="puzzle-score">
                   {renderPuzzleResult(node.resultText)}
                 </div>
               </div>
@@ -71,9 +71,15 @@ const DailyPuzzle = ({ data, pageContext }) => {
 }
 
 const renderPuzzleResult = (text) => {
-  const lines = text.split('\n')
-  const result = lines.map((line) => <Twemoji options={{ className: 'twemoji-puzzle', folder: 'svg', ext: '.svg' }}>{line}</Twemoji>)
-  return result;
+  const lines = text.split("\n")
+  const result = lines.map((line) => (
+    <Twemoji
+      options={{ className: "twemoji-puzzle", folder: "svg", ext: ".svg" }}
+    >
+      {line}
+    </Twemoji>
+  ))
+  return result
 }
 
 export default DailyPuzzle


### PR DESCRIPTION
Initially tried using `react-emoji-renderer` package but some emojis, in my case the 🟨 emoji, wasn't detected as an emoji and thus, wasn't rendered. Switched to `react-twemoji` instead.