### PR TITLE
Add menu options in puzzle scores and blog pages

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -64,5 +64,6 @@ module.exports = {
     `gatsby-plugin-emotion`,
     `gatsby-plugin-react-helmet`,
     `gatsby-plugin-netlify`,
+    `gatsby-plugin-anchor-links`,
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "dotenv": "^16.0.1",
         "gatsby": "^4.19.2",
         "gatsby-plugin-ackee-tracker": "^3.2.4",
+        "gatsby-plugin-anchor-links": "^1.2.1",
         "gatsby-plugin-emotion": "^7.19.0",
         "gatsby-plugin-image": "^2.24.0",
         "gatsby-plugin-netlify": "^5.0.1",
@@ -10197,6 +10198,14 @@
         "gatsby": "^3.0.0 || ^4.0.0"
       }
     },
+    "node_modules/gatsby-plugin-anchor-links": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-anchor-links/-/gatsby-plugin-anchor-links-1.2.1.tgz",
+      "integrity": "sha512-BIhhljCxIUVluMltlCq5sKvVN9PfwqoUNaTjyPZUhtEu5JhEiK89HPNustSkjSLhnQmcYveS36TpjWK/rUnvhg==",
+      "dependencies": {
+        "scroll-to-element": "^2.0.3"
+      }
+    },
     "node_modules/gatsby-plugin-emotion": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-emotion/-/gatsby-plugin-emotion-7.19.0.tgz",
@@ -15342,6 +15351,11 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+    },
     "node_modules/physical-cpu-count": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/physical-cpu-count/-/physical-cpu-count-2.0.0.tgz",
@@ -16503,6 +16517,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dependencies": {
+        "performance-now": "^2.1.0"
       }
     },
     "node_modules/ramda": {
@@ -17738,6 +17760,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/scroll-to-element": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/scroll-to-element/-/scroll-to-element-2.0.3.tgz",
+      "integrity": "sha512-5herPcm9jMfQgRwu94lH5mei+2YhipR4RQ2nAvnBxJb2tG+P7O0ctOKAaAZBXbBejnn+MImh3wrAUA5EcLnjEQ==",
+      "dependencies": {
+        "raf": "^3.4.0"
       }
     },
     "node_modules/section-matter": {
@@ -28351,6 +28381,14 @@
         "cross-env": "^7.0.3"
       }
     },
+    "gatsby-plugin-anchor-links": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-anchor-links/-/gatsby-plugin-anchor-links-1.2.1.tgz",
+      "integrity": "sha512-BIhhljCxIUVluMltlCq5sKvVN9PfwqoUNaTjyPZUhtEu5JhEiK89HPNustSkjSLhnQmcYveS36TpjWK/rUnvhg==",
+      "requires": {
+        "scroll-to-element": "^2.0.3"
+      }
+    },
     "gatsby-plugin-emotion": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-emotion/-/gatsby-plugin-emotion-7.19.0.tgz",
@@ -32048,6 +32086,11 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+    },
     "physical-cpu-count": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/physical-cpu-count/-/physical-cpu-count-2.0.0.tgz",
@@ -32817,6 +32860,14 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+    },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
     },
     "ramda": {
       "version": "0.21.0",
@@ -33724,6 +33775,14 @@
         "@types/json-schema": "^7.0.5",
         "ajv": "^6.12.4",
         "ajv-keywords": "^3.5.2"
+      }
+    },
+    "scroll-to-element": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/scroll-to-element/-/scroll-to-element-2.0.3.tgz",
+      "integrity": "sha512-5herPcm9jMfQgRwu94lH5mei+2YhipR4RQ2nAvnBxJb2tG+P7O0ctOKAaAZBXbBejnn+MImh3wrAUA5EcLnjEQ==",
+      "requires": {
+        "raf": "^3.4.0"
       }
     },
     "section-matter": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dotenv": "^16.0.1",
     "gatsby": "^4.19.2",
     "gatsby-plugin-ackee-tracker": "^3.2.4",
+    "gatsby-plugin-anchor-links": "^1.2.1",
     "gatsby-plugin-emotion": "^7.19.0",
     "gatsby-plugin-image": "^2.24.0",
     "gatsby-plugin-netlify": "^5.0.1",

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -11,7 +11,7 @@ import SliderBurger from "./slider-burger"
 import Logo from "../../static/icons/logo.svg"
 import siteData from "../config/site-data.yml"
 
-let { menuOptions } = siteData
+const { menuOptions } = siteData
 
 const Header = ({
   currentPage,

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -9,8 +9,12 @@ import { breakpoint, transitionTiming } from "../styles/theme"
 import { throttle } from "../utils"
 import SliderBurger from "./slider-burger"
 import Logo from "../../static/icons/logo.svg"
+import siteData from "../config/site-data.yml"
+
+let { menuOptions } = siteData
 
 const Header = ({
+  currentPage,
   height,
   isSticky,
   hasMenu,
@@ -49,6 +53,10 @@ const Header = ({
       window.removeEventListener("resize", () => handleResize())
     }
   })
+
+  menuOptions = menuOptions.filter(
+    (o) => o.link !== currentPage && (!o.anchorIn || o.anchorIn === currentPage)
+  )
 
   return (
     <header
@@ -122,6 +130,7 @@ const Header = ({
         </div>
         {hasMenu && (
           <NavList
+            menuOptions={menuOptions}
             customCss={css`
               ${breakpoint.maxMedia7} {
                 display: none;
@@ -144,6 +153,7 @@ const Header = ({
 
       {hasMenu && (
         <NavOverlay
+          menuOptions={menuOptions}
           onToggleMenu={onToggleMenu}
           backgroundColor={navBackground}
           isVisible={isMenuOpen}

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -54,7 +54,7 @@ const Header = ({
     }
   })
 
-  menuOptions = menuOptions.filter(
+  let filteredMenu = menuOptions.filter(
     (o) => o.link !== currentPage && (!o.anchorIn || o.anchorIn === currentPage)
   )
 
@@ -130,7 +130,7 @@ const Header = ({
         </div>
         {hasMenu && (
           <NavList
-            menuOptions={menuOptions}
+            menuOptions={filteredMenu}
             customCss={css`
               ${breakpoint.maxMedia7} {
                 display: none;
@@ -153,7 +153,7 @@ const Header = ({
 
       {hasMenu && (
         <NavOverlay
-          menuOptions={menuOptions}
+          menuOptions={filteredMenu}
           onToggleMenu={onToggleMenu}
           backgroundColor={navBackground}
           isVisible={isMenuOpen}

--- a/src/components/loader.js
+++ b/src/components/loader.js
@@ -95,7 +95,7 @@ const LoaderLine = styled.div`
 
 const Loader = ({ finishLoading }) => {
   useEffect(() => {
-    const timeout = setTimeout(() => finishLoading(), 1500)
+    const timeout = setTimeout(() => finishLoading(), 800)
     return () => clearTimeout(timeout)
   }, [finishLoading])
 

--- a/src/components/nav-list.js
+++ b/src/components/nav-list.js
@@ -2,7 +2,6 @@ import React from "react"
 import { css } from "@emotion/react"
 
 import { NavLinkItem } from "../styles/Links"
-import siteData from "../config/site-data.yml"
 
 const itemStyle = css`
   font-size: 0.8rem;
@@ -19,10 +18,9 @@ const NavList = (props) => (
       ${props.customCss};
     `}
   >
-    {siteData.menuOptions.map(({ title, link, isInternal }) => (
+    {props.menuOptions.map(({ title, link }) => (
       <NavLinkItem
         link={link}
-        isInternal={isInternal}
         onClick={props.onToggleMenu}
         customCss={itemStyle}
       >

--- a/src/components/nav-overlay.js
+++ b/src/components/nav-overlay.js
@@ -5,7 +5,7 @@ import IconLink from "./icon-link"
 import { NavLinkItem } from "../styles/Links"
 import siteData from "../config/site-data.yml"
 
-const { menuOptions, socialMediaLinks } = siteData
+const { socialMediaLinks } = siteData
 
 const itemStyle = css`
   margin: 1rem 0;
@@ -35,10 +35,9 @@ const NavOverlay = (props) => (
       align-items: center;
     `}
   >
-    {menuOptions.map(({ title, link, isInternal }) => (
+    {props.menuOptions.map(({ title, link }) => (
       <NavLinkItem
         link={link}
-        isInternal={isInternal}
         onClick={props.onToggleMenu}
         customCss={itemStyle}
       >

--- a/src/config/site-data.yml
+++ b/src/config/site-data.yml
@@ -57,16 +57,18 @@ profile:
 
     I also write about my learnings, insights and experiences in my <a href="#latestBlogPosts">blog</a>.
 menuOptions:
+  - title: Home
+    link: '/'
   - title: About
-    link: '#about'
+    link: '/#about'
+    anchorIn: '/'
   - title: Blog
     link: '/blog'
-    isInternal: true
   - title: Contact
-    link: '#contact'
+    link: '/#contact'
+    anchorIn: '/'
   - title: Puzzle Scores
     link: '/puzzle-scores'
-    isInternal: true
 socialMediaLinks:
   - id: github
     link: https://github.com/galiarmero

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import { Link, graphql } from "gatsby"
 import { css } from "@emotion/react"
 
@@ -17,6 +17,8 @@ import sharingCard from "../../static/images/sharing-card.png"
 const { profile, siteBaseUrl } = siteData
 
 const Blog = ({ data }) => {
+  const [isMenuOpen, toggleMenu] = useState(false)
+
   const author = profile.name
   const headerHeight = 75
   const posts = data.allMarkdownRemark.edges
@@ -32,9 +34,13 @@ const Blog = ({ data }) => {
       />
       <GlobalStyles />
       <Header
+        currentPage={`/blog`}
         height={headerHeight}
         navBackground={colors.lighterBg}
         logoSuffix="blog"
+        hasMenu={true}
+        isMenuOpen={isMenuOpen}
+        onToggleMenu={() => toggleMenu(!isMenuOpen)}
       />
       <Main marginTop={`${headerHeight}px`}>
         <div

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -96,6 +96,7 @@ const Index = () => {
       ) : (
         <div>
           <Header
+            currentPage={`/`}
             height={headerHeight}
             isSticky={true}
             hasMenu={true}

--- a/src/styles/Links.js
+++ b/src/styles/Links.js
@@ -6,7 +6,7 @@ export const NavLinkItem = (props) => (
   <div css={props.customCss}>
     <AnchorLink
       to={props.link}
-      onClick={props.onClick}
+      onAnchorLinkClick={props.onClick}
       css={navLinkStyle}
       duration={2000}
     >

--- a/src/styles/Links.js
+++ b/src/styles/Links.js
@@ -1,18 +1,17 @@
 import React from "react"
-import { Link } from "gatsby"
+import { AnchorLink } from "gatsby-plugin-anchor-links"
 import { css } from "@emotion/react"
 
 export const NavLinkItem = (props) => (
   <div css={props.customCss}>
-    {props.isInternal ? (
-      <Link to={props.link} onClick={props.onClick} css={navLinkStyle}>
-        {props.children}
-      </Link>
-    ) : (
-      <a href={props.link} onClick={props.onClick} css={navLinkStyle}>
-        {props.children}
-      </a>
-    )}
+    <AnchorLink
+      to={props.link}
+      onClick={props.onClick}
+      css={navLinkStyle}
+      duration={2000}
+    >
+      {props.children}
+    </AnchorLink>
   </div>
 )
 

--- a/src/templates/puzzle-scores.js
+++ b/src/templates/puzzle-scores.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import { graphql } from "gatsby"
 import { css } from "@emotion/react"
 import Linkify from "linkify-react"
@@ -47,6 +47,8 @@ const PuzzleBox = styled(Card)`
 `
 
 const DailyPuzzle = ({ data, pageContext }) => {
+  const [isMenuOpen, toggleMenu] = useState(false)
+
   const puzzles = data.allPuzzleScores.edges.sort((a, b) => {
     return (
       PUZZLE_ORDER.indexOf(a.node.puzzle) - PUZZLE_ORDER.indexOf(b.node.puzzle)
@@ -67,7 +69,14 @@ const DailyPuzzle = ({ data, pageContext }) => {
       />
       <GlobalStyles />
       <DailyPuzzleStyles />
-      <Header height={HEADER_HEIGHT} navBackground={colors.lighterBg} />
+      <Header
+        currentPage={`/puzzle-scores`}
+        height={HEADER_HEIGHT}
+        navBackground={colors.lighterBg}
+        hasMenu={true}
+        isMenuOpen={isMenuOpen}
+        onToggleMenu={() => toggleMenu(!isMenuOpen)}
+      />
       <Main marginTop={`${HEADER_HEIGHT}px`}>
         <div
           css={css`


### PR DESCRIPTION
Initial goal was to just put the menu on both pages. But including `About` and `Contact` links resulted in crappy behavior where the page doesn't scroll to the anchored section (e.g. `/#about`) even if `gatsby-plugin-anchor-links`. This is likely because of animations in the home page.

As compromise, only show links to pages outside the current page or anchors in the current page.