### PR TITLE
Fix twemoji rendering after MaxCDN shutdown

### DIFF
--- a/src/templates/puzzle-scores.js
+++ b/src/templates/puzzle-scores.js
@@ -140,7 +140,7 @@ const renderPuzzleResult = ({ puzzle, resultText, fields }) => {
   const result = lines.map((line) => (
     <Linkify options={linkifyOpts}>
       <Twemoji
-        options={{ className: "twemoji-puzzle", folder: "svg", ext: ".svg" }}
+        options={{ className: "twemoji-puzzle", folder: "svg", ext: ".svg", base: "https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/" }}
       >
         {line}
       </Twemoji>

--- a/src/templates/puzzle-scores.js
+++ b/src/templates/puzzle-scores.js
@@ -140,7 +140,12 @@ const renderPuzzleResult = ({ puzzle, resultText, fields }) => {
   const result = lines.map((line) => (
     <Linkify options={linkifyOpts}>
       <Twemoji
-        options={{ className: "twemoji-puzzle", folder: "svg", ext: ".svg", base: "https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/" }}
+        options={{
+          className: "twemoji-puzzle",
+          folder: "svg",
+          ext: ".svg",
+          base: "https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/",
+        }}
       >
         {line}
       </Twemoji>


### PR DESCRIPTION
Twemoji uses MaxCDN as the default CDN to use when rendering emojis. Recently, MaxCDN has shutdown, causing emojis to not be rendered. Solution is to change the CDN by supplying the `base` option for `twemoji.parse`. In `react-twemoji`, we simply pass this in the `option` property. Here, I used `cdn.jsdelivr.net` as suggested in the issue below.

See https://github.com/twitter/twemoji/issues/580.