### PR TITLE
Retry Nenoy API requests when server is idle

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,44 +1,20 @@
 const path = require(`path`)
 const { performance } = require(`perf_hooks`)
 const axios = require(`axios`)
+const nenoyApi = require('./src/utils/nenoy-api')
 const { createFilePath } = require(`gatsby-source-filesystem`)
 
 exports.sourceNodes = async ({ actions, createContentDigest }) => {
   const { createNode } = actions
-
-  const {
-    NENOY_API_BASE_URL,
-    NENOY_API_USER,
-    NENOY_API_PASS,
-    NENOY_API_TIMEOUT,
-    PUZZLE_SCORES_PER_PAGE,
-  } = process.env
-
-  const nenoyApi = axios.create({
-    baseURL: NENOY_API_BASE_URL,
-    auth: {
-      username: NENOY_API_USER,
-      password: NENOY_API_PASS,
-    },
-    timeout: NENOY_API_TIMEOUT,
-  })
+  const { PUZZLE_SCORES_PER_PAGE } = process.env
 
   console.log(
     `Fetching puzzle scores from Nenoy API, ${PUZZLE_SCORES_PER_PAGE} at a time`
   )
   let startAt
   while (true) {
-    let url =
-      `/puzzle-scores?limit=${PUZZLE_SCORES_PER_PAGE}` +
-      (startAt ? `&startAt=${startAt}` : "")
-    let response
     let requestStartTime = performance.now()
-    try {
-      response = await nenoyApi.get(url)
-    } catch (e) {
-      console.error(e)
-      throw e
-    }
+    let response = await nenoyApi.getPuzzleScores(PUZZLE_SCORES_PER_PAGE, startAt)
     console.log(
       `Got ${
         response.data.puzzleScores.length

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,7 +1,7 @@
 const path = require(`path`)
 const { performance } = require(`perf_hooks`)
 const axios = require(`axios`)
-const nenoyApi = require('./src/utils/nenoy-api')
+const nenoyApi = require("./src/utils/nenoy-api")
 const { createFilePath } = require(`gatsby-source-filesystem`)
 
 exports.sourceNodes = async ({ actions, createContentDigest }) => {
@@ -14,7 +14,10 @@ exports.sourceNodes = async ({ actions, createContentDigest }) => {
   let startAt
   while (true) {
     let requestStartTime = performance.now()
-    let response = await nenoyApi.getPuzzleScores(PUZZLE_SCORES_PER_PAGE, startAt)
+    let response = await nenoyApi.getPuzzleScores(
+      PUZZLE_SCORES_PER_PAGE,
+      startAt
+    )
     console.log(
       `Got ${
         response.data.puzzleScores.length

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/styled": "^11.9.3",
         "@researchgate/react-intersection-observer": "^1.1.2",
         "axios": "^1.1.2",
+        "axios-retry": "^3.4.0",
         "dayjs": "^1.8.20",
         "dotenv": "^16.0.1",
         "gatsby": "^4.19.2",
@@ -5296,13 +5297,22 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
-      "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.4.0.tgz",
+      "integrity": "sha512-VdgaP+gHH4iQYCCNUWF2pcqeciVOdGrBBAYUfTY+wPcO5Ltvp/37MLFNCmJKo7Gj3SHvCSdL8ouI1qLYJN3liA==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
@@ -12796,6 +12806,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-root": {
@@ -24599,9 +24620,9 @@
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w=="
     },
     "axios": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
-      "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -24618,6 +24639,15 @@
             "mime-types": "^2.1.12"
           }
         }
+      }
+    },
+    "axios-retry": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.4.0.tgz",
+      "integrity": "sha512-VdgaP+gHH4iQYCCNUWF2pcqeciVOdGrBBAYUfTY+wPcO5Ltvp/37MLFNCmJKo7Gj3SHvCSdL8ouI1qLYJN3liA==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "axobject-query": {
@@ -30137,6 +30167,11 @@
       "requires": {
         "is-absolute-url": "^3.0.0"
       }
+    },
+    "is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
     },
     "is-root": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@emotion/styled": "^11.9.3",
     "@researchgate/react-intersection-observer": "^1.1.2",
     "axios": "^1.1.2",
+    "axios-retry": "^3.4.0",
     "dayjs": "^1.8.20",
     "dotenv": "^16.0.1",
     "gatsby": "^4.19.2",

--- a/src/utils/nenoy-api.js
+++ b/src/utils/nenoy-api.js
@@ -1,4 +1,3 @@
-
 const axios = require(`axios`)
 const axiosRetry = require(`axios-retry`)
 
@@ -14,8 +13,8 @@ const {
 const nenoyApi = axios.create({
   baseURL: NENOY_API_BASE_URL,
   auth: {
-      username: NENOY_API_USER,
-      password: NENOY_API_PASS,
+    username: NENOY_API_USER,
+    password: NENOY_API_PASS,
   },
   timeout: NENOY_API_TIMEOUT,
 })
@@ -25,20 +24,22 @@ axiosRetry(nenoyApi, {
   retryDelay: () => NENOY_API_RETRY_DELAY,
   shouldResetTimeout: true,
   retryCondition: (error) => {
-      console.log(`[DEBUG] Error found: ${error}`)
-      console.log(`[DEBUG] Error code found: ${error.code}`)
-      return axiosRetry.isNetworkOrIdempotentRequestError(error)
-              || error.code === 'ECONNABORTED'
+    console.log(`[DEBUG] Error found: ${error}`)
+    console.log(`[DEBUG] Error code found: ${error.code}`)
+    return (
+      axiosRetry.isNetworkOrIdempotentRequestError(error) ||
+      error.code === "ECONNABORTED"
+    )
   },
   onRetry: (retryCount, error, requestConfig) => {
-      console.log(`Attempting retry number ${retryCount} after error: ${error}`)
-      return
+    console.log(`Attempting retry number ${retryCount} after error: ${error}`)
+    return
   },
 })
 
 const getPuzzleScores = async (limit, startAt = null) => {
-  let url = `/puzzle-scores?limit=${limit}` +
-              (startAt ? `&startAt=${startAt}` : "")
+  let url =
+    `/puzzle-scores?limit=${limit}` + (startAt ? `&startAt=${startAt}` : "")
   try {
     return nenoyApi.get(url)
   } catch (e) {

--- a/src/utils/nenoy-api.js
+++ b/src/utils/nenoy-api.js
@@ -1,0 +1,52 @@
+
+const axios = require(`axios`)
+const axiosRetry = require(`axios-retry`)
+
+const {
+  NENOY_API_BASE_URL,
+  NENOY_API_USER,
+  NENOY_API_PASS,
+  NENOY_API_TIMEOUT,
+  NENOY_API_RETRY_MAX,
+  NENOY_API_RETRY_DELAY,
+} = process.env
+
+const nenoyApi = axios.create({
+  baseURL: NENOY_API_BASE_URL,
+  auth: {
+      username: NENOY_API_USER,
+      password: NENOY_API_PASS,
+  },
+  timeout: NENOY_API_TIMEOUT,
+})
+
+axiosRetry(nenoyApi, {
+  retries: NENOY_API_RETRY_MAX,
+  retryDelay: () => NENOY_API_RETRY_DELAY,
+  shouldResetTimeout: true,
+  retryCondition: (error) => {
+      console.log(`[DEBUG] Error found: ${error}`)
+      console.log(`[DEBUG] Error code found: ${error.code}`)
+      return axiosRetry.isNetworkOrIdempotentRequestError(error)
+              || error.code === 'ECONNABORTED'
+  },
+  onRetry: (retryCount, error, requestConfig) => {
+      console.log(`Attempting retry number ${retryCount} after error: ${error}`)
+      return
+  },
+})
+
+const getPuzzleScores = async (limit, startAt = null) => {
+  let url = `/puzzle-scores?limit=${limit}` +
+              (startAt ? `&startAt=${startAt}` : "")
+  try {
+    return nenoyApi.get(url)
+  } catch (e) {
+    console.error(e)
+    throw e
+  }
+}
+
+module.exports = {
+  getPuzzleScores,
+}


### PR DESCRIPTION
Per Render.com's [Free Web Services](https://render.com/docs/free#free-web-services) doc, services are spun down after 15 mins of inactivity. It will take up to 30 secs to respond when waking up from this sleep.

This change adds a retry mechanism to resiliently handle such scenarios that cause builds to fail, requiring manual intervention.