### PR TITLE
Hardcode metadata for NY Times Mini link preview

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -71,9 +71,9 @@ exports.onCreateNode = async ({ node, getNode, actions }) => {
   } else if (node.internal.type === `PuzzleScores`) {
     if (node.puzzle === `nytimes-mini-crossword`) {
       const url = new URL(node.resultText.match(/\bhttps?:\/\/\S+/gi)[0])
-      const date = url.searchParams.get('d')
-      const solveTime = url.searchParams.get('t')
-      const c = url.searchParams.get('c')
+      const date = url.searchParams.get("d")
+      const solveTime = url.searchParams.get("t")
+      const c = url.searchParams.get("c")
       createNodeField({
         node,
         name: `linkPreview`,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -70,20 +70,19 @@ exports.onCreateNode = async ({ node, getNode, actions }) => {
     })
   } else if (node.internal.type === `PuzzleScores`) {
     if (node.puzzle === `nytimes-mini-crossword`) {
-      const url = node.resultText.match(/\bhttps?:\/\/\S+/gi)[0]
-      const response = await axios.get(
-        `https://jsonlink.io/api/extract?url=${encodeURIComponent(url)}`
-      )
-      const { title, description, images, domain } = response.data
+      const url = new URL(node.resultText.match(/\bhttps?:\/\/\S+/gi)[0])
+      const date = url.searchParams.get('d')
+      const solveTime = url.searchParams.get('t')
+      const c = url.searchParams.get('c')
       createNodeField({
         node,
         name: `linkPreview`,
         value: {
-          title,
-          description,
-          image: images[0],
-          url,
-          domain,
+          title: `Play The Mini Crossword`,
+          description: `All the fun of the larger New York Times Crossword, but you can solve it in seconds.`,
+          image: `https://www.nytimes.com/badges/games/mini.jpg?d=${date}&t=${solveTime}&c=${c}`,
+          url: url.toString(),
+          domain: `www.nytimes.com`,
         },
       })
     }


### PR DESCRIPTION
Getting 404 errors when using `jsonlink.io` API to fetch link preview metadata for NY Times Mini. Looks like the issue is fixed now but to avoid future problems, we'll use hardcoded metadata instead of fetching for metadata for each score. The data is easy to determine anyway.

**Pro**: Reduces overhead by avoiding hundreds of calls done for every NY Times Mini score
**Con**: If the real-time metadata changes (e.g. title, description or preview image), we won't notice right away and keep up
